### PR TITLE
PN-2358 campi senderDenomination e senderTaxId resi required

### DIFF
--- a/docs/openapi/api-external-b2b-pa-v1.yaml
+++ b/docs/openapi/api-external-b2b-pa-v1.yaml
@@ -653,10 +653,10 @@ components:
           example: '1220'
           type: string
         effectiveDate:
-          description: notification effective date
+          description: notification effective IT local date
           type: string
           format: date-time
-          example: 2017-07-21T17:32:59.645442Z
+          #example: 2017-07-21T17:32:59.645442Z
 
     ###########################################################################################
     ###                              DTO RICHIESTE DI NOTIFICA                              ###

--- a/docs/openapi/schemas-pn-notification-v1.yaml
+++ b/docs/openapi/schemas-pn-notification-v1.yaml
@@ -58,11 +58,13 @@ components:
         - documents
         - physicalCommunicationType
         - notificationFeePolicy
+        - senderDenomination
+        - senderTaxId
       properties:
         idempotenceToken:
           description: >-
             Identificativo utilizzabile dal chiamante per disambiguare differenti 
-            "richieste di notificazione" effetuate con lo stesso numero di protocollo 
+            "richieste di notificazione" effettuate con lo stesso numero di protocollo 
             (campo _paProtocolNumber_). Questo può essere necessario in caso di 
             "richiesta di notifica" rifiutata per errori nei codici di verifica degli
             allegati.

--- a/src/test/java/it/pagopa/pn/delivery/svc/NotificationReceiverTest.java
+++ b/src/test/java/it/pagopa/pn/delivery/svc/NotificationReceiverTest.java
@@ -398,6 +398,8 @@ class NotificationReceiverTest {
 						notificationReferredAttachment()
 				))
 				.group( "Group_1" )
+				.senderTaxId( "01199250158" )
+				.senderDenomination( "Comune di Milano" )
 				.build();
 	}
 

--- a/src/test/java/it/pagopa/pn/delivery/svc/NotificationReceiverValidationTest.java
+++ b/src/test/java/it/pagopa/pn/delivery/svc/NotificationReceiverValidationTest.java
@@ -13,12 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.util.Base64Utils;
 
 import javax.validation.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -69,7 +67,9 @@ class NotificationReceiverValidationTest {
         assertConstraintViolationPresentByField( errors, "physicalCommunicationType" );
         assertConstraintViolationPresentByField( errors, "subject" );
         assertConstraintViolationPresentByField( errors, "notificationFeePolicy" );
-        Assertions.assertEquals( 11, errors.size() );
+        assertConstraintViolationPresentByField( errors, "senderDenomination" );
+        assertConstraintViolationPresentByField( errors, "senderTaxId" );
+        Assertions.assertEquals( 13, errors.size() );
     }
 
     @Test
@@ -97,7 +97,9 @@ class NotificationReceiverValidationTest {
         assertProblemErrorConstraintViolationPresentByField( errors, "physicalCommunicationType" );
         assertProblemErrorConstraintViolationPresentByField( errors, "subject" );
         assertProblemErrorConstraintViolationPresentByField( errors, "notificationFeePolicy" );
-        Assertions.assertEquals( 11, errors.size() );
+        assertProblemErrorConstraintViolationPresentByField( errors, "senderDenomination" );
+        assertProblemErrorConstraintViolationPresentByField( errors, "senderTaxId" );
+        Assertions.assertEquals( 13, errors.size() );
     }
 
     @Test


### PR DESCRIPTION
La soluzione adottata è stata quella di rendere obbligatori i campi senderDenomination e senderTaxId nella Request Body.