### PR TITLE
geature/PN-2194

### DIFF
--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -248,6 +248,7 @@ Resources:
       Parameters:
         WAFName: !Sub '${ProjectName}-delivery-web'
         APIGatewayARNs: !GetAtt DeliveryMicroservicePublicWebAPI.Outputs.APIGatewayARN
+        Limit: 6000
 
   # Expose PN-Delivery microservice public API with API-GW for IO Backend usage
   DeliveryMicroservicePublicIoAPI:


### PR DESCRIPTION
Limite chaimate web impostato a 20 al secondo (6000 ogni 5 minuti) per indirizzo IP