### PR TITLE
PN-2925 gestione errori audit log

### DIFF
--- a/src/main/java/it/pagopa/pn/delivery/rest/PnInternalNotificationsController.java
+++ b/src/main/java/it/pagopa/pn/delivery/rest/PnInternalNotificationsController.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.delivery.rest;
 
+import it.pagopa.pn.commons.exceptions.PnRuntimeException;
 import it.pagopa.pn.commons.log.PnAuditLogBuilder;
 import it.pagopa.pn.commons.log.PnAuditLogEvent;
 import it.pagopa.pn.commons.log.PnAuditLogEventType;
@@ -58,7 +59,12 @@ public class PnInternalNotificationsController implements InternalOnlyApi {
         try {
             response = priceService.getNotificationCost( paTaxId, noticeCode );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("Exception on get notification private= " + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure("Exception on get notification cost private= " + exc.getMessage()).log();
             throw exc;
         }
@@ -85,7 +91,12 @@ public class PnInternalNotificationsController implements InternalOnlyApi {
         try {
             responseCheckAarDto = qrService.getNotificationByQR( requestCheckAarDto );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("Exception on get notification qr private= " + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure("Exception on get notification qr private= " + exc.getMessage()).log();
             throw exc;
         }
@@ -121,7 +132,12 @@ public class PnInternalNotificationsController implements InternalOnlyApi {
         try {
             statusService.updateStatus(requestUpdateStatusDto);
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(logMessage).log();
             throw exc;
         }
@@ -160,7 +176,12 @@ public class PnInternalNotificationsController implements InternalOnlyApi {
             ModelMapper mapper = modelMapperFactory.createModelMapper(ResultPaginationDto.class, NotificationSearchResponse.class );
             response = mapper.map( serviceResult, NotificationSearchResponse.class );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }
@@ -187,7 +208,12 @@ public class PnInternalNotificationsController implements InternalOnlyApi {
                     false
             );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }
@@ -213,7 +239,12 @@ public class PnInternalNotificationsController implements InternalOnlyApi {
                     false
             );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }

--- a/src/main/java/it/pagopa/pn/delivery/rest/PnNotificationPriceController.java
+++ b/src/main/java/it/pagopa/pn/delivery/rest/PnNotificationPriceController.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.delivery.rest;
 
+import it.pagopa.pn.commons.exceptions.PnRuntimeException;
 import it.pagopa.pn.commons.log.PnAuditLogBuilder;
 import it.pagopa.pn.commons.log.PnAuditLogEvent;
 import it.pagopa.pn.commons.log.PnAuditLogEventType;
@@ -33,7 +34,12 @@ public class PnNotificationPriceController implements NotificationPriceApi {
         try {
             response = service.getNotificationPrice( paTaxId, noticeCode );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("Exception on get notification price= " + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure("Exception on get notification price= " + exc.getMessage()).log();
             throw exc;
         }

--- a/src/main/java/it/pagopa/pn/delivery/rest/PnReceivedNotificationsController.java
+++ b/src/main/java/it/pagopa/pn/delivery/rest/PnReceivedNotificationsController.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.delivery.rest;
 
+import it.pagopa.pn.commons.exceptions.PnRuntimeException;
 import it.pagopa.pn.commons.log.PnAuditLogBuilder;
 import it.pagopa.pn.commons.log.PnAuditLogEvent;
 import it.pagopa.pn.commons.log.PnAuditLogEventType;
@@ -66,7 +67,12 @@ public class PnReceivedNotificationsController implements RecipientReadApi {
             ModelMapper mapper = modelMapperFactory.createModelMapper(ResultPaginationDto.class, NotificationSearchResponse.class);
             response = mapper.map(serviceResult, NotificationSearchResponse.class);
             logEvent.generateSuccess().log();
-        } catch (Exception exc ){
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc ){
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }
@@ -90,7 +96,12 @@ public class PnReceivedNotificationsController implements RecipientReadApi {
             result = mapper.map(internalNotification, FullReceivedNotification.class);
 
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }
@@ -116,7 +127,12 @@ public class PnReceivedNotificationsController implements RecipientReadApi {
                     true
             );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }
@@ -144,7 +160,12 @@ public class PnReceivedNotificationsController implements RecipientReadApi {
                     true
             );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }
@@ -168,7 +189,12 @@ public class PnReceivedNotificationsController implements RecipientReadApi {
         try {
             responseCheckAarMandateDto = notificationQRService.getNotificationByQRWithMandate( requestCheckAarMandateDto, xPagopaPnCxType.getValue(), xPagopaPnCxId );
             logEvent.generateSuccess().log();
-        } catch ( Exception exc ) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("Exception on get notification by qr= " + e.getProblem()).log();
+            throw e;
+        }
+        catch ( Exception exc ) {
             logEvent.generateFailure( "Exception on get notification by qr= " + exc.getMessage()).log();
             throw exc;
         }

--- a/src/main/java/it/pagopa/pn/delivery/rest/PnSentNotificationsController.java
+++ b/src/main/java/it/pagopa/pn/delivery/rest/PnSentNotificationsController.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.delivery.rest;
 
+import it.pagopa.pn.commons.exceptions.PnRuntimeException;
 import it.pagopa.pn.commons.log.PnAuditLogBuilder;
 import it.pagopa.pn.commons.log.PnAuditLogEvent;
 import it.pagopa.pn.commons.log.PnAuditLogEventType;
@@ -27,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static it.pagopa.pn.commons.exceptions.PnExceptionsCodes.ERROR_CODE_PN_GENERIC_INVALIDPARAMETER_REQUIRED;
 
@@ -88,7 +88,12 @@ public class PnSentNotificationsController implements SenderReadB2BApi,SenderRea
             ModelMapper mapper = modelMapperFactory.createModelMapper(ResultPaginationDto.class, NotificationSearchResponse.class );
             response = mapper.map( serviceResult, NotificationSearchResponse.class );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }
@@ -185,7 +190,12 @@ public class PnSentNotificationsController implements SenderReadB2BApi,SenderRea
                     false
             );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }
@@ -212,7 +222,12 @@ public class PnSentNotificationsController implements SenderReadB2BApi,SenderRea
                     false
             );
             logEvent.generateSuccess().log();
-        } catch (Exception exc) {
+        }
+        catch (PnRuntimeException e) {
+            logEvent.generateFailure("" + e.getProblem()).log();
+            throw e;
+        }
+        catch (Exception exc) {
             logEvent.generateFailure(exc.getMessage()).log();
             throw exc;
         }


### PR DESCRIPTION
In caso venga lanciata una eccezione di PnRuntimeException (e sottotipi), nel message di AUDIT LOG viene stampato il toString di Problem.

**Esempio di message di AUDIT  LOG prima dell'intervento:**
"message": "[AUD_NT_INSERT] FAILURE - Bad Request"

**Esempio di message di AUDIT LOG dopo l'intervento:**
   "message":"[AUD_NT_INSERT] FAILURE - [protocolNumber=paProtocolNumber2, idempotenceToken=null] class Problem {\n    type: GENERIC_ERROR\n    status: 400\n    title: Bad Request\n    detail: Input non valido\n    traceId: trace_id:7a6ed5cb-a0ff-46fc-9318-5c741254091c\n    timestamp: 2023-01-03T14:49:23.394307Z\n    errors: [class ProblemError {\n        code: PN_DELIVERY_INVALIDPARAMETER_GROUP\n        element: group1\n        detail: Group=group1 not present in cx_groups=[sbagliato]\n    }]\n}"

