### PR TITLE
PN-4842: update codegen config to handle commonFiles; openapi updates

### DIFF
--- a/codegen/config.json
+++ b/codegen/config.json
@@ -9,6 +9,9 @@
         },
         {
             "intendedUsage": "B2B",
+            "commonFiles": [
+                "schemas-pn-notification.yaml"
+            ],
             "openapiFiles": [
                 "api-internal-b2b-pa.yaml"
             ],

--- a/docs/openapi/api-external-b2b-pa-bundle.yaml
+++ b/docs/openapi/api-external-b2b-pa-bundle.yaml
@@ -1176,9 +1176,6 @@ components:
             - PG
         taxId:
           $ref: '#/components/schemas/TaxId'
-        internalId:
-          type: string
-          description: id interno anonimizzato
         denomination:
           $ref: '#/components/schemas/Denomination'
         digitalDomicile:

--- a/docs/openapi/aws/api-delivery-B2B-aws.yaml
+++ b/docs/openapi/aws/api-delivery-B2B-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: 2offH0p6FvNLltjlb9Kif8iwIs7S1GNugG8pHzPv9gM=
+  version: Hv/28PwZZik7p2bwvwsP3W6QI+z0nPGXW5YbPssZMQ0=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -1419,9 +1419,6 @@ components:
             - PG
         taxId:
           $ref: '#/components/schemas/TaxId'
-        internalId:
-          type: string
-          description: id interno anonimizzato
         denomination:
           $ref: '#/components/schemas/Denomination'
         digitalDomicile:

--- a/docs/openapi/aws/api-delivery-WEB-aws.yaml
+++ b/docs/openapi/aws/api-delivery-WEB-aws.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: >-
     ${stageVariables.ProjectName}-${stageVariables.MicroServiceUniqueName}-${stageVariables.IntendedUsage}
-  version: FQP1eBZo4OuQfJOk+8PL2W6FqHwFpTQFxwsqIl4/Hpg=
+  version: 6Mo3nN1Ht6xbakSLkzPLggL1w9NKiuQq5D0mG2pF+Bk=
 servers:
   - url: https://${stageVariables.DnsName}/{basePath}
     variables:
@@ -1965,9 +1965,6 @@ components:
             - PG
         taxId:
           $ref: '#/components/schemas/TaxId'
-        internalId:
-          type: string
-          description: id interno anonimizzato
         denomination:
           $ref: '#/components/schemas/Denomination'
         digitalDomicile:

--- a/docs/openapi/schemas-pn-notification.yaml
+++ b/docs/openapi/schemas-pn-notification.yaml
@@ -201,9 +201,9 @@ components:
             - PG
         taxId:
           $ref: '#/components/schemas/TaxId'
-        internalId:
-          type: string
-          description: id interno anonimizzato
+        internalId:  # NO EXTERNAL       
+          type: string # NO EXTERNAL    
+          description: id interno anonimizzato # NO EXTERNAL    
         denomination:
           $ref: '#/components/schemas/Denomination'
         digitalDomicile:

--- a/src/test/java/it/pagopa/pn/delivery/springbootcfg/NotificationRecipentSerializationTest.java
+++ b/src/test/java/it/pagopa/pn/delivery/springbootcfg/NotificationRecipentSerializationTest.java
@@ -1,0 +1,38 @@
+package it.pagopa.pn.delivery.springbootcfg;
+
+import it.pagopa.pn.delivery.generated.openapi.server.v1.dto.NotificationRecipient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.json.JsonContent;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JsonTest
+class NotificationRecipentSerializationTest {
+
+    @Autowired
+    private JacksonTester<NotificationRecipient> jacksonTester;
+
+
+    @Test
+    void notificationRecipientSerializationTest() throws IOException {
+        NotificationRecipient recipient = new NotificationRecipient()
+                .recipientType(NotificationRecipient.RecipientTypeEnum.PF)
+                .denomination("Mario Rossi")
+                .taxId("CCCCCCCC")
+                .internalId(null);
+
+        JsonContent<NotificationRecipient> json = jacksonTester.write(recipient);
+
+        System.out.println(json.getJson());
+
+        assertThat(json).hasJsonPath("recipientType")
+                .hasJsonPath("denomination")
+                .hasJsonPath("taxId")
+                .doesNotHaveJsonPath("internalId");
+    }
+}


### PR DESCRIPTION
In attesa di aggiornare la versione del codegen nel parent pom, ho generato i nuovi file openapi sfruttando il nuovo attributo del file di configurazione codegen `commonFiles` che contiene la lista degli schemas openapi sui quali applicare le trasformazioni.