### PR TITLE
aggiornamento-swagger

### DIFF
--- a/docs/openapi/api-external-b2b-pa-bundle.yaml
+++ b/docs/openapi/api-external-b2b-pa-bundle.yaml
@@ -630,11 +630,11 @@ components:
           type: integer
           format: int32
         refinementDate:
-          description: data di perfezionamento per decorrenza termini localizzata
+          description: data di perfezionamento per decorrenza termini localizzata espressa alla mezzanotte del giorno in cui si verifica l'evento
           type: string
           format: date-time
         notificationViewDate:
-          description: data di perfezionamento per presa visione
+          description: data di perfezionamento per presa visione espressa alla mezzanotte del giorno in cui si verifica l'evento
           type: string
           format: date-time
     NewNotificationResponse:

--- a/docs/openapi/api-external-b2b-pa.yaml
+++ b/docs/openapi/api-external-b2b-pa.yaml
@@ -874,11 +874,11 @@ components:
           type: integer
           format: int32
         refinementDate:
-          description: data di perfezionamento per decorrenza termini localizzata
+          description: data di perfezionamento per decorrenza termini localizzata espressa alla mezzanotte del giorno in cui si verifica l'evento
           type: string
           format: date-time
         notificationViewDate:
-          description: data di perfezionamento per presa visione
+          description: data di perfezionamento per presa visione espressa alla mezzanotte del giorno in cui si verifica l'evento
           type: string
           format: date-time
 

--- a/docs/openapi/api-internal-b2b-pa.yaml
+++ b/docs/openapi/api-internal-b2b-pa.yaml
@@ -978,11 +978,11 @@ components:
           type: integer
           format: int32
         refinementDate:
-          description: data di perfezionamento per decorrenza termini localizzata
+          description: data di perfezionamento per decorrenza termini localizzata espressa alla mezzanotte del giorno in cui si verifica l'evento
           type: string
           format: date-time
         notificationViewDate:
-          description: data di perfezionamento per presa visione
+          description: data di perfezionamento per presa visione espressa alla mezzanotte del giorno in cui si verifica l'evento
           type: string
           format: date-time
 


### PR DESCRIPTION
- integrata descrizione delle date refinementDate e notificationViewDate restituite dal servizio NotificationPrice per precisare che si tratta di date espresse alla mezzanotte del giorni in cui si verifica l'evento