### PR TITLE
PN-7516 inibizione attachments e documents per notifiche cancellate

### DIFF
--- a/docs/openapi/remote-refs.yaml
+++ b/docs/openapi/remote-refs.yaml
@@ -46,9 +46,9 @@ components:
     ############################################################################################
     
     pathLegalFactType:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/5bbfdf63511b62901dfd8c4705cfb69c39eec878/docs/openapi/api-internal-pn-delivery-push.yaml#/components/parameters/pathLegalFactType'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/2998bad11c862b9c260eda2925f5736386654124/docs/openapi/api-internal-pn-delivery-push.yaml#/components/parameters/pathLegalFactType'
     pathLegalFactId: 
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/5bbfdf63511b62901dfd8c4705cfb69c39eec878/docs/openapi/api-internal-pn-delivery-push.yaml#/components/parameters/pathLegalFactId'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/2998bad11c862b9c260eda2925f5736386654124/docs/openapi/api-internal-pn-delivery-push.yaml#/components/parameters/pathLegalFactId'
 
 
   schemas:
@@ -57,13 +57,13 @@ components:
     ###                          STRUTTURE DATI DI PN-DELIVERY_PUSH                          ###
     ############################################################################################
     TimelineElement: 
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/5bbfdf63511b62901dfd8c4705cfb69c39eec878/docs/openapi/schemas-pn-timeline.yaml#/components/schemas/TimelineElement'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/2998bad11c862b9c260eda2925f5736386654124/docs/openapi/schemas-pn-timeline.yaml#/components/schemas/TimelineElement'
     NotificationStatus:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/5bbfdf63511b62901dfd8c4705cfb69c39eec878/docs/openapi/schemas-pn-status.yaml#/components/schemas/NotificationStatus'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/2998bad11c862b9c260eda2925f5736386654124/docs/openapi/schemas-pn-status.yaml#/components/schemas/NotificationStatus'
     NotificationStatusHistory:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/5bbfdf63511b62901dfd8c4705cfb69c39eec878/docs/openapi/schemas-pn-status.yaml#/components/schemas/NotificationStatusHistory'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/2998bad11c862b9c260eda2925f5736386654124/docs/openapi/schemas-pn-status.yaml#/components/schemas/NotificationStatusHistory'
     LegalFactDownloadMetadataResponse:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/5bbfdf63511b62901dfd8c4705cfb69c39eec878/docs/openapi/schemas-pn-legal-facts.yaml#/components/schemas/LegalFactDownloadMetadataResponse'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/2998bad11c862b9c260eda2925f5736386654124/docs/openapi/schemas-pn-legal-facts.yaml#/components/schemas/LegalFactDownloadMetadataResponse'
 
     ############################################################################################
     ###                          STRUTTURE DATI DI PN-COMMONS                                ###

--- a/docs/openapi/schemas-pn-timeline-appio.yaml
+++ b/docs/openapi/schemas-pn-timeline-appio.yaml
@@ -779,8 +779,8 @@ components:
   ###########################################################
 
     DigitalAddress:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/5767743f485b5de261aaa80ac06cde340b10580e/docs/openapi/schemas-addresses-v1.yaml#/components/schemas/DigitalAddress'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/2998bad11c862b9c260eda2925f5736386654124/docs/openapi/schemas-addresses-v1.yaml#/components/schemas/DigitalAddress'
 
     PhysicalAddress:
-      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/5767743f485b5de261aaa80ac06cde340b10580e/docs/openapi/schemas-addresses-v1.yaml#/components/schemas/PhysicalAddress'
+      $ref: 'https://raw.githubusercontent.com/pagopa/pn-delivery-push/2998bad11c862b9c260eda2925f5736386654124/docs/openapi/schemas-addresses-v1.yaml#/components/schemas/PhysicalAddress'
 

--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
                         </goals>
                         <phase>process-resources</phase>
                         <configuration>
-                            <inputSpec>https://raw.githubusercontent.com/pagopa/pn-delivery-push/5bbfdf63511b62901dfd8c4705cfb69c39eec878/docs/openapi/api-private.yaml</inputSpec>
+                            <inputSpec>https://raw.githubusercontent.com/pagopa/pn-delivery-push/2998bad11c862b9c260eda2925f5736386654124/docs/openapi/api-private.yaml</inputSpec>
                             <generatorName>java</generatorName>
                             <library>resttemplate</library>
                             <generateApiTests>false</generateApiTests>

--- a/src/main/java/it/pagopa/pn/delivery/rest/PnReceivedNotificationsController.java
+++ b/src/main/java/it/pagopa/pn/delivery/rest/PnReceivedNotificationsController.java
@@ -170,13 +170,14 @@ public class PnReceivedNotificationsController implements RecipientReadApi {
             eventType = PnAuditLogEventType.AUD_NT_DOCOPEN_DEL;
             logMsg = "getDelegateNotificationDocument from documents array with index={} with mandateId={}";
         }
-        NotificationAttachmentDownloadMetadataResponse response = new NotificationAttachmentDownloadMetadataResponse();
+        NotificationAttachmentDownloadMetadataResponse response;
         PnAuditLogEvent logEvent = auditLogBuilder
                 .before(eventType, logMsg, docIdx, mandateId)
                 .iun(iun)
                 .build();
         logEvent.log();
         try {
+            retrieveSvc.checkIfNotificationIsNotCancelled(iun);
             InternalAuthHeader internalAuthHeader = new InternalAuthHeader(xPagopaPnCxType.getValue(), xPagopaPnCxId, xPagopaPnUid, xPagopaPnCxGroups);
             response = notificationAttachmentService.downloadDocumentWithRedirect(
                     iun,
@@ -190,12 +191,11 @@ public class PnReceivedNotificationsController implements RecipientReadApi {
             String retryAfter = String.valueOf( response.getRetryAfter() );
             String message = LogUtils.createAuditLogMessageForDownloadDocument(fileName, url, retryAfter);
             logEvent.generateSuccess("getReceivedNotificationDocument {}", message).log();
+            return ResponseEntity.ok(response);
         } catch (PnRuntimeException exc) {
             logEvent.generateFailure("" + exc.getProblem()).log();
             throw exc;
         }
-
-        return ResponseEntity.ok(response);
     }
 
 
@@ -208,12 +208,13 @@ public class PnReceivedNotificationsController implements RecipientReadApi {
             eventType = PnAuditLogEventType.AUD_NT_ATCHOPEN_DEL;
             logMsg = "getReceivedAndDelegatedNotificationAttachment attachment name={} and mandateId={}";
         }
-        NotificationAttachmentDownloadMetadataResponse response = new NotificationAttachmentDownloadMetadataResponse();
+        NotificationAttachmentDownloadMetadataResponse response;
         PnAuditLogEvent logEvent = auditLogBuilder.before(eventType, logMsg, attachmentName, mandateId)
                 .iun(iun)
                 .build();
         logEvent.log();
         try {
+            retrieveSvc.checkIfNotificationIsNotCancelled(iun);
             InternalAuthHeader internalAuthHeader = new InternalAuthHeader(xPagopaPnCxType.getValue(), xPagopaPnCxId, xPagopaPnUid, xPagopaPnCxGroups);
             response = notificationAttachmentService.downloadAttachmentWithRedirect(
                     iun,
@@ -229,11 +230,11 @@ public class PnReceivedNotificationsController implements RecipientReadApi {
             String message = LogUtils.createAuditLogMessageForDownloadDocument(fileName, url, retryAfter);
             logEvent.generateSuccess("getReceivedNotificationAttachment attachment name={}, {}",
                     attachmentName, message).log();
+            return ResponseEntity.ok(response);
         } catch (PnRuntimeException exc) {
             logEvent.generateFailure("" + exc.getProblem()).log();
             throw exc;
         }
-        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/src/main/java/it/pagopa/pn/delivery/svc/search/NotificationRetrieverService.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/search/NotificationRetrieverService.java
@@ -818,4 +818,23 @@ public class NotificationRetrieverService {
 		return recIndex;
 	}
 
+	public void checkIfNotificationIsNotCancelled(String iun) {
+		if(isNotificationCancelled(iun)) {
+			throw new PnNotificationNotFoundException(String.format("Notification with iun: %s has a request for cancellation", iun));
+		}
+ 	}
+
+	public boolean isNotificationCancelled(String iun) {
+		InternalNotification notification = getNotificationInformation(iun);
+		TimelineElementCategory cancellationRequestCategory = TimelineElementCategory.NOTIFICATION_CANCELLATION_REQUEST;
+		Optional<TimelineElement> cancellationRequestTimeline = notification.getTimeline().stream()
+				.filter(timelineElement -> cancellationRequestCategory.toString().equals(timelineElement.getCategory().toString()))
+				.findFirst();
+		boolean cancellationTimelineIsPresent = cancellationRequestTimeline.isPresent();
+		if(cancellationTimelineIsPresent) {
+			log.warn("Notification with iun: {} has a request for cancellation", iun);
+		}
+		return cancellationTimelineIsPresent;
+	}
+
 }

--- a/src/test/java/it/pagopa/pn/delivery/rest/PnSentReceivedNotificationControllerTest.java
+++ b/src/test/java/it/pagopa/pn/delivery/rest/PnSentReceivedNotificationControllerTest.java
@@ -1093,4 +1093,34 @@ class PnSentReceivedNotificationControllerTest {
 				.isBadRequest();
 
 	}
+
+	@Test
+	void getReceivedNotificationDocumentWithNotificationCancelledTest() {
+		Mockito.doThrow(new PnNotificationNotFoundException("Notification with iun: a-iun has a request for cancellation"))
+				.when(svc)
+				.checkIfNotificationIsNotCancelled(IUN);
+
+		webTestClient.get()
+				.uri("/delivery/notifications/received/{iun}/attachments/documents/{docIdx}", IUN, 1)
+				.header( PnDeliveryRestConstants.CX_ID_HEADER, RECIPIENT_ID)
+				.header(PnDeliveryRestConstants.UID_HEADER, UID)
+				.header(PnDeliveryRestConstants.CX_TYPE_HEADER, "PF")
+				.exchange()
+				.expectStatus().isNotFound();
+	}
+
+	@Test
+	void getReceivedNotificationAttachmentWithNotificationCancelledTest() {
+		Mockito.doThrow(new PnNotificationNotFoundException("Notification with iun: a-iun has a request for cancellation"))
+				.when(svc)
+				.checkIfNotificationIsNotCancelled(IUN);
+
+		webTestClient.get()
+				.uri("/delivery/notifications/received/{iun}/attachments/payment/{attachmentName}", IUN, "PAGOPA")
+				.header( PnDeliveryRestConstants.CX_ID_HEADER, RECIPIENT_ID)
+				.header(PnDeliveryRestConstants.UID_HEADER, UID)
+				.header(PnDeliveryRestConstants.CX_TYPE_HEADER, "PF")
+				.exchange()
+				.expectStatus().isNotFound();
+	}
 }


### PR DESCRIPTION
Log di esempio dell'errore:

```
2023-08-30 14:09:46,287 [trace_id:331d068a-a28c-4e17-a244-4ab1ac15c61f] WARN  - 640804 - [reactor-http-nio-5] - i.p.p.c.e.ExceptionHelper - pn-exception 404 catched problem=class Problem {
    type: GENERIC_ERROR
    status: 404
    title: Notification not found
    detail: Notification with iun: WHPG-DAGR-KEAN-202306-Q-1 has a request for cancellation
    traceId: trace_id:331d068a-a28c-4e17-a244-4ab1ac15c61f
    timestamp: 2023-08-30T12:09:46.287169Z
    errors: [class ProblemError {
        code: PN_DELIVERY_NOTIFICATIONNOTFOUND
        element: null
        detail: none
    }]
} 
```

Esempio di response:

```
{
    "detail": "See logs for details in PN-DELIVERY",
    "errors": [
        {
            "code": "PN_DELIVERY_NOTIFICATIONNOTFOUND",
            "detail": "none"
        }
    ],
    "status": 404,
    "timestamp": "2023-08-30T12:09:46.287169Z",
    "title": "Handled error",
    "traceId": "trace_id:331d068a-a28c-4e17-a244-4ab1ac15c61f",
    "type": "GENERIC_ERROR"
}
```
