### PR TITLE
PN-7367

### DIFF
--- a/src/main/java/it/pagopa/pn/delivery/svc/NotificationReceiverValidator.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/NotificationReceiverValidator.java
@@ -82,6 +82,7 @@ public class NotificationReceiverValidator {
 
         int recIdx = 0;
         Set<String> distinctTaxIds = new HashSet<>();
+        Set<String> distinctIuvs = new HashSet<>();
         for (NotificationRecipientV21 recipient : newNotificationRequestV2.getRecipients()) {
 
             // limitazione temporanea: destinatari PG possono avere solo TaxId numerico
@@ -99,6 +100,7 @@ public class NotificationReceiverValidator {
             boolean isNotificationFeePolicyDeliveryMode = newNotificationRequestV2.getNotificationFeePolicy().equals(NotificationFeePolicy.DELIVERY_MODE);
             if(recipient.getPayments() != null) {
                 errors.addAll(checkApplyCost(isNotificationFeePolicyDeliveryMode, recipient.getPayments()));
+                errors.addAll(checkIuvs(recipient.getPayments(), distinctIuvs, recIdx));
             }
 
             NotificationPhysicalAddress physicalAddress = recipient.getPhysicalAddress();
@@ -194,6 +196,26 @@ public class NotificationReceiverValidator {
                 errors.add(constraintViolation);
             }
         }
+    }
+
+    public Set<ConstraintViolation<NewNotificationRequestV21>> checkIuvs(List<NotificationPaymentItem> payments, Set<String> iuvSet, int recIdx) {
+        Set<ConstraintViolation<NewNotificationRequestV21>> errors = new HashSet<>();
+        int paymIdx = 0;
+        for (NotificationPaymentItem payment : payments) {
+            if(payment.getPagoPa() != null) {
+                String iuv = payment.getPagoPa().getCreditorTaxId() + payment.getPagoPa().getNoticeCode();
+
+                if ( !iuvSet.add( iuv ) ) {
+                    String errorMsg = String.format("Duplicated iuv { %s } on recipient with index %s in payment with index %s", iuv, recIdx, paymIdx);
+                    ConstraintViolationImpl<NewNotificationRequestV21> constraintViolation = new ConstraintViolationImpl<>(errorMsg);
+                    errors.add(constraintViolation);
+                }
+            }
+
+            paymIdx++;
+        }
+
+        return errors;
     }
 
 

--- a/src/test/java/it/pagopa/pn/delivery/svc/NotificationReceiverTest.java
+++ b/src/test/java/it/pagopa/pn/delivery/svc/NotificationReceiverTest.java
@@ -352,9 +352,9 @@ class NotificationReceiverTest {
 		NewNotificationRequestV21 newNotificationRequest = newNotificationRequest();
 		newNotificationRequest.setRecipients(
 				List.of(
-						buildRecipient("LVLDAA85T50G702B", 8),
-						buildRecipient("DSRDNI00A01A225I", 7),
-						buildRecipient("GLLGLL64B15G702I", 9))
+						buildRecipient("LVLDAA85T50G702B", "888888888888888888"),
+						buildRecipient("DSRDNI00A01A225I", "777777777777777777"),
+						buildRecipient("GLLGLL64B15G702I", "999999999999999999"))
 		);
 
 		// When
@@ -394,9 +394,9 @@ class NotificationReceiverTest {
 		NewNotificationRequestV21 newNotificationRequest = newNotificationRequest();
 		newNotificationRequest.setRecipients(
 				List.of(
-						buildRecipient("LVLDAA85T50G702B", 8),
-						buildRecipient("DSRDNI00A01A225I", 7),
-						buildRecipient("GLLGLL64B15G702I", 9))
+						buildRecipient("LVLDAA85T50G702B", "888888888888888888"),
+						buildRecipient("DSRDNI00A01A225I", "777777777777777777"),
+						buildRecipient("GLLGLL64B15G702I", "999999999999999999"))
 		);
 
 		// When
@@ -514,6 +514,7 @@ class NotificationReceiverTest {
 		// Given
 		NewNotificationRequestV21 notification = NewNotificationRequestV21.builder()
 				.senderTaxId( "fakeSenderTaxId" )
+				.paProtocolNumber("test")
 				.notificationFeePolicy(NotificationFeePolicy.DELIVERY_MODE)
 				.recipients( Collections.singletonList( NotificationRecipientV21.builder().build() ) )
 				.documents( Collections.singletonList( NotificationDocument.builder().build() ) )
@@ -651,7 +652,7 @@ class NotificationReceiverTest {
 				.notificationFeePolicy( NotificationFeePolicy.FLAT_RATE )
 				.paProtocolNumber( "paProtocolNumber" )
 				.recipients( Collections.singletonList(
-						buildRecipient("LVLDAA85T50G702B", 8) ))
+						buildRecipient("LVLDAA85T50G702B", "888888888888888888") ))
 				.physicalCommunicationType( NewNotificationRequestV21.PhysicalCommunicationTypeEnum.REGISTERED_LETTER_890 )
 				._abstract( "abstract" )
 				.build();
@@ -730,13 +731,13 @@ class NotificationReceiverTest {
 		return notification;
 	}
 
-	private NotificationRecipientV21 buildRecipient(String taxID, int noticeCode){
+	private NotificationRecipientV21 buildRecipient(String taxID, String noticeCode){
 		return NotificationRecipientV21.builder()
 				.payments( List.of(NotificationPaymentItem.builder()
 						.pagoPa(PagoPaPayment.builder()
 								.creditorTaxId("00000000000")
 								.applyCost(false)
-								.noticeCode("000000000000000000")
+								.noticeCode(noticeCode)
 								.build())
 						.f24(F24Payment.builder()
 								.title("title")


### PR DESCRIPTION
Aggiunto controllo di validazione nuova notifica: Tutti gli IUV devono essere univoci all'interno del payload della richiesta di creazione notifica.