### PR TITLE
feat(PN-19361): Add BS cx type support to authorization check 

### DIFF
--- a/src/main/java/it/pagopa/pn/delivery/svc/NotificationAttachmentService.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/NotificationAttachmentService.java
@@ -31,6 +31,7 @@ import it.pagopa.pn.delivery.pnclient.pnf24.PnF24ClientImpl;
 import it.pagopa.pn.delivery.pnclient.safestorage.PnSafeStorageClientImpl;
 import it.pagopa.pn.delivery.svc.authorization.AuthorizationOutcome;
 import it.pagopa.pn.delivery.svc.authorization.CheckAuthComponent;
+import it.pagopa.pn.delivery.svc.authorization.ReadAccessAction;
 import it.pagopa.pn.delivery.svc.authorization.ReadAccessAuth;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -236,7 +237,7 @@ public class NotificationAttachmentService {
         Boolean markNotificationAsViewed = inputDownloadDto.getMarkNotificationAsViewed();
         log.info("downloadDocumentWithRedirect for cxType={} iun={} documentIndex={} recipientIdx={} xPagopaPnCxId={} attachmentName={} mandateId={} markNotificationAsViewed={} attachmentIndex={}", cxType, iun, documentIndex, recipientIdx, cxId, attachmentName, mandateId, markNotificationAsViewed, attachmentIdx);
 
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, cxGroups, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, cxGroups, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         Optional<InternalNotification> optNotification = notificationDao.getNotificationByIun(iun, false);
         if (optNotification.isPresent()) {

--- a/src/main/java/it/pagopa/pn/delivery/svc/PaymentEventsService.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/PaymentEventsService.java
@@ -14,6 +14,7 @@ import it.pagopa.pn.delivery.models.internal.notification.NotificationRecipient;
 import it.pagopa.pn.delivery.pnclient.datavault.PnDataVaultClientImpl;
 import it.pagopa.pn.delivery.svc.authorization.AuthorizationOutcome;
 import it.pagopa.pn.delivery.svc.authorization.CheckAuthComponent;
+import it.pagopa.pn.delivery.svc.authorization.ReadAccessAction;
 import it.pagopa.pn.delivery.svc.authorization.ReadAccessAuth;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -78,7 +79,7 @@ public class PaymentEventsService {
             }
 
             // controllo autorizzazione
-            ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest( cxType, xPagopaPnCxId, null, xPagopaPnCxGroups, iun, recipientIdx );
+            ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest( cxType, xPagopaPnCxId, null, xPagopaPnCxGroups, iun, recipientIdx, ReadAccessAction.HANDLE_PAYMENTS );
             AuthorizationOutcome authorizationOutcome = checkAuthComponent.canAccess( readAccessAuth, internalNotification );
 
             if ( !authorizationOutcome.isAuthorized() ) {

--- a/src/main/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponent.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponent.java
@@ -34,9 +34,10 @@ public class CheckAuthComponent {
         CxType cxType = action.getCxType();
 
         return switch (cxType) {
-            case PA, BS -> paCanAccess(action, notification);
+            case PA -> paCanAccess(action, notification);
             case PF -> pfCanAccess(action, notification);
             case PG -> pgCanAccess(action, notification);
+            case BS -> bsCanAccess(action, notification);
         };
     }
 
@@ -136,8 +137,20 @@ public class CheckAuthComponent {
     }
 
     private AuthorizationOutcome paCanAccess(ReadAccessAuth action, InternalNotification notification) {
+        return senderCanAccess(action, notification);
+    }
+
+    private AuthorizationOutcome bsCanAccess(ReadAccessAuth action, InternalNotification notification) {
+        if (action.getAction() != ReadAccessAction.DOWNLOAD_DOCUMENTS) {
+            log.warn("bsCanAccess action {} not allowed for cxType BS", action.getAction());
+            return AuthorizationOutcome.fail();
+        }
+        return senderCanAccess(action, notification);
+    }
+
+    private AuthorizationOutcome senderCanAccess(ReadAccessAuth action, InternalNotification notification) {
         String senderId = action.getCxId();
-        log.debug( "Check if senderId={} can access iun={}", senderId, notification.getIun() );
+        log.debug( "Check if senderId={} cxType={} can access iun={}", senderId, action.getCxType(), notification.getIun() );
         boolean authorized = senderId.equals( notification.getSenderPaId() );
         AuthorizationOutcome result;
         if ( authorized ) {

--- a/src/main/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponent.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponent.java
@@ -34,7 +34,7 @@ public class CheckAuthComponent {
         CxType cxType = action.getCxType();
 
         return switch (cxType) {
-            case PA -> paCanAccess(action, notification);
+            case PA, BS -> paCanAccess(action, notification);
             case PF -> pfCanAccess(action, notification);
             case PG -> pgCanAccess(action, notification);
         };

--- a/src/main/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponent.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponent.java
@@ -157,7 +157,11 @@ public class CheckAuthComponent {
             Integer recipientIdx = action.getRecipientIdx();
             NotificationRecipient effectiveRecipient = null;
             if ( recipientIdx != null && recipientIdx >= 0 ) {
-                effectiveRecipient = notification.getRecipients().get(recipientIdx);
+                if ( recipientIdx < notification.getRecipients().size() ) {
+                    effectiveRecipient = notification.getRecipients().get(recipientIdx);
+                } else {
+                    log.warn( "senderCanAccess recipientIdx={} out of bounds (recipients size={}) iun={}", recipientIdx, notification.getRecipients().size(), notification.getIun() );
+                }
             }
             result = AuthorizationOutcome.ok(effectiveRecipient, recipientIdx);
         } else {

--- a/src/main/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponent.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponent.java
@@ -155,13 +155,13 @@ public class CheckAuthComponent {
         AuthorizationOutcome result;
         if ( authorized ) {
             Integer recipientIdx = action.getRecipientIdx();
+            if ( recipientIdx != null && recipientIdx >= notification.getRecipients().size() ) {
+                log.warn( "senderCanAccess recipientIdx={} out of bounds (recipients size={}) iun={}", recipientIdx, notification.getRecipients().size(), notification.getIun() );
+                return AuthorizationOutcome.fail();
+            }
             NotificationRecipient effectiveRecipient = null;
             if ( recipientIdx != null && recipientIdx >= 0 ) {
-                if ( recipientIdx < notification.getRecipients().size() ) {
-                    effectiveRecipient = notification.getRecipients().get(recipientIdx);
-                } else {
-                    log.warn( "senderCanAccess recipientIdx={} out of bounds (recipients size={}) iun={}", recipientIdx, notification.getRecipients().size(), notification.getIun() );
-                }
+                effectiveRecipient = notification.getRecipients().get(recipientIdx);
             }
             result = AuthorizationOutcome.ok(effectiveRecipient, recipientIdx);
         } else {

--- a/src/main/java/it/pagopa/pn/delivery/svc/authorization/CxType.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/authorization/CxType.java
@@ -1,5 +1,5 @@
 package it.pagopa.pn.delivery.svc.authorization;
 
 public enum CxType {
-    PA,PF,PG
+    PA,PF,PG,BS
 }

--- a/src/main/java/it/pagopa/pn/delivery/svc/authorization/ReadAccessAction.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/authorization/ReadAccessAction.java
@@ -1,0 +1,5 @@
+package it.pagopa.pn.delivery.svc.authorization;
+
+public enum ReadAccessAction {
+    DOWNLOAD_DOCUMENTS, HANDLE_PAYMENTS
+}

--- a/src/main/java/it/pagopa/pn/delivery/svc/authorization/ReadAccessAuth.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/authorization/ReadAccessAuth.java
@@ -17,6 +17,7 @@ public class ReadAccessAuth {
     private ReadAccessAction action;
 
     public static ReadAccessAuth newAccessRequest(String cxType, String cxId, String mandateId, List<String> cxGroups, String iun, Integer recipientIdx, ReadAccessAction action) {
+        Objects.requireNonNull(action, "ReadAccessAuth action must not be null");
         ReadAccessAuth result = new ReadAccessAuth();
         result.setCxType( CxType.valueOf( cxType ) );
         result.setCxId( cxId );

--- a/src/main/java/it/pagopa/pn/delivery/svc/authorization/ReadAccessAuth.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/authorization/ReadAccessAuth.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.delivery.svc.authorization;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Objects;
 
 @Data
 public class ReadAccessAuth {

--- a/src/main/java/it/pagopa/pn/delivery/svc/authorization/ReadAccessAuth.java
+++ b/src/main/java/it/pagopa/pn/delivery/svc/authorization/ReadAccessAuth.java
@@ -14,8 +14,9 @@ public class ReadAccessAuth {
 
     private String iun;
     private Integer recipientIdx;
+    private ReadAccessAction action;
 
-    public static ReadAccessAuth newAccessRequest(String cxType, String cxId, String mandateId, List<String> cxGroups, String iun, Integer recipientIdx) {
+    public static ReadAccessAuth newAccessRequest(String cxType, String cxId, String mandateId, List<String> cxGroups, String iun, Integer recipientIdx, ReadAccessAction action) {
         ReadAccessAuth result = new ReadAccessAuth();
         result.setCxType( CxType.valueOf( cxType ) );
         result.setCxId( cxId );
@@ -23,6 +24,7 @@ public class ReadAccessAuth {
         result.setCxGroups( cxGroups );
         result.setIun( iun );
         result.setRecipientIdx( recipientIdx );
+        result.setAction( action );
         return result;
     }
 

--- a/src/test/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponentTest.java
+++ b/src/test/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponentTest.java
@@ -62,7 +62,7 @@ class CheckAuthComponentTest {
 
 
     @ParameterizedTest
-    @ValueSource(strings = {"PG", "PF", "PA"})
+    @ValueSource(strings = {"PG", "PF", "PA", "BS"})
     void canAccessPFPGPAUnauthorized(String cxType) {
         String cxId = "CX_ID";
         String iun = "IUN_01";
@@ -245,6 +245,24 @@ class CheckAuthComponentTest {
         Assertions.assertThrows( PnNotFoundException.class, todo);
     }
 
+
+    @Test
+    void canAccessBSSuccess() {
+        String cxType = "BS";
+        String cxId = "PA_ID";
+        String iun = "IUN_01";
+        Integer recipientIdx = 0;
+
+        InternalNotification notification = newNotification();
+        // Given
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx);
+
+        // When
+        AuthorizationOutcome authorizationOutcome = checkAuthComponent.canAccess( readAccessAuth, notification );
+
+        // Then
+        Assertions.assertTrue( authorizationOutcome.isAuthorized() );
+    }
 
     @Test
     void canAccessPASuccess() {

--- a/src/test/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponentTest.java
+++ b/src/test/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponentTest.java
@@ -51,7 +51,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, null);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         // When
         Executable todo = () -> checkAuthComponent.canAccess( readAccessAuth, notification );
@@ -62,7 +62,7 @@ class CheckAuthComponentTest {
 
 
     @ParameterizedTest
-    @ValueSource(strings = {"PG", "PF", "PA", "BS"})
+    @ValueSource(strings = {"PG", "PF", "PA"})
     void canAccessPFPGPAUnauthorized(String cxType) {
         String cxId = "CX_ID";
         String iun = "IUN_01";
@@ -70,7 +70,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, null);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         // When
         AuthorizationOutcome authorizationOutcome = checkAuthComponent.canAccess( readAccessAuth, notification );
@@ -90,7 +90,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -127,7 +127,7 @@ class CheckAuthComponentTest {
         notification.setRecipientIds(List.of("recipientId"));
         notification.setRecipients(List.of(NotificationRecipient.builder().taxId("taxId").recipientType(NotificationRecipientV24.RecipientTypeEnum.PF).build()));
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -162,7 +162,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -196,7 +196,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -225,7 +225,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -291,7 +291,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, null);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         // When
         AuthorizationOutcome authorizationOutcome = checkAuthComponent.canAccess( readAccessAuth, notification );

--- a/src/test/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponentTest.java
+++ b/src/test/java/it/pagopa/pn/delivery/svc/authorization/CheckAuthComponentTest.java
@@ -51,7 +51,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, null);
 
         // When
         Executable todo = () -> checkAuthComponent.canAccess( readAccessAuth, notification );
@@ -70,7 +70,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, null);
 
         // When
         AuthorizationOutcome authorizationOutcome = checkAuthComponent.canAccess( readAccessAuth, notification );
@@ -90,7 +90,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -127,7 +127,7 @@ class CheckAuthComponentTest {
         notification.setRecipientIds(List.of("recipientId"));
         notification.setRecipients(List.of(NotificationRecipient.builder().taxId("taxId").recipientType(NotificationRecipientV24.RecipientTypeEnum.PF).build()));
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -162,7 +162,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -196,7 +196,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -225,7 +225,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, mandateId, null, iun, recipientIdx, null);
 
         // When
         Mockito.when( externalRegistriesClient.getRootSenderId(notification.getSenderPaId())).thenReturn("rootSenderId");
@@ -247,7 +247,7 @@ class CheckAuthComponentTest {
 
 
     @Test
-    void canAccessBSSuccess() {
+    void canAccessBSDownloadDocumentsSuccess() {
         String cxType = "BS";
         String cxId = "PA_ID";
         String iun = "IUN_01";
@@ -255,13 +255,31 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, ReadAccessAction.DOWNLOAD_DOCUMENTS);
 
         // When
         AuthorizationOutcome authorizationOutcome = checkAuthComponent.canAccess( readAccessAuth, notification );
 
         // Then
         Assertions.assertTrue( authorizationOutcome.isAuthorized() );
+    }
+
+    @Test
+    void canAccessBSHandlePaymentsFail() {
+        String cxType = "BS";
+        String cxId = "PA_ID";
+        String iun = "IUN_01";
+        Integer recipientIdx = 0;
+
+        InternalNotification notification = newNotification();
+        // Given
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, ReadAccessAction.HANDLE_PAYMENTS);
+
+        // When
+        AuthorizationOutcome authorizationOutcome = checkAuthComponent.canAccess( readAccessAuth, notification );
+
+        // Then
+        Assertions.assertFalse( authorizationOutcome.isAuthorized() );
     }
 
     @Test
@@ -273,7 +291,7 @@ class CheckAuthComponentTest {
 
         InternalNotification notification = newNotification();
         // Given
-        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx);
+        ReadAccessAuth readAccessAuth = ReadAccessAuth.newAccessRequest(cxType, cxId, null, null, iun, recipientIdx, null);
 
         // When
         AuthorizationOutcome authorizationOutcome = checkAuthComponent.canAccess( readAccessAuth, notification );


### PR DESCRIPTION
  ### Motivation      
                                                                                                                                                                                                           
  `BS` (backstage) clients must be able to download notification documents but must not be allowed to handle payments. Introducing `ReadAccessAction` makes these restrictions explicit and          
  enforceable at the authorization layer rather than scattered across service methods.

  - Added `BS` to the CxType enum as a new supported client type.
  - Introduced the ReadAccessAction enum (DOWNLOAD_DOCUMENTS, HANDLE_PAYMENTS) to represent the type of access requested, and extended ReadAccessAuth with an action field.
  - Added `bsCanAccess` in CheckAuthComponent: `BS` is authorized only for DOWNLOAD_DOCUMENTS; any other action (e.g. HANDLE_PAYMENTS) is rejected. The shared sender-matching logic is extracted into         
  senderCanAccess, which also logs the cxType.                                                                                                                                                             
  - Updated NotificationAttachmentService and PaymentEventsService to pass the appropriate ReadAccessAction when building ReadAccessAuth.